### PR TITLE
Fix: ColorManagementPacket Duration is not correctly converted to Little Endian Bytes

### DIFF
--- a/src/main/java/io/github/robvanderleek/jlifx/packet/ColorManagementPacket.java
+++ b/src/main/java/io/github/robvanderleek/jlifx/packet/ColorManagementPacket.java
@@ -14,13 +14,14 @@ class ColorManagementPacket extends Packet {
         byte[] saturationBytes = floatToBytes(hsbValues[1]);
         byte[] brightnessBytes = floatToBytes(brightness);
         byte[] kelvin = new byte[]{0x0a, (byte) 0xf0};
+        byte[] duration = intToBytes(fadetime);
         byte[] payload = new byte[]{streaming, //
                 hueBytes[1], hueBytes[0], //
                 saturationBytes[1], saturationBytes[0], //
                 brightnessBytes[1], brightnessBytes[0], //
                 kelvin[1], //
                 kelvin[0], //
-                0x00, (byte) fadetime, 0x00, 0x00};
+                duration[3], duration[2], duration[1], duration[0]};
         setPayload(payload);
     }
 


### PR DESCRIPTION
As indicated, the duration is incorrectly applied into the packet.